### PR TITLE
Ship now supports multiple rings

### DIFF
--- a/gameboard.js
+++ b/gameboard.js
@@ -80,10 +80,10 @@ function initializeScoreBoardLives(lives) {
  * This function shows a 2 line message to the player.
  */
 function showMessage(line1, line2) {
-  const message = document.getElementById("message-overlay");
+  const message = document.getElementById('message-overlay');
   message.style.display = 'block';
-  document.getElementById("message-line1").innerHTML = line1;
-  document.getElementById("message-line2").innerHTML = line2;
+  document.getElementById('message-line1').innerHTML = line1;
+  document.getElementById('message-line2').innerHTML = line2;
 }
 
 function showStaticMessage(type) {
@@ -118,16 +118,26 @@ function clearMessageBoard() {
 }
 
 /**
- * Shows an indicator message that will disappear after 2000ms
- * @param {String} type The type of message that will be shown
+ * Shows a control message with the given text as the content
+ * A control message is shown at the center bottom of the screen
+ * @param {String} content The message that will be shown to the user
  */
-function showTimedMessage(type) {
+function showControlMessage(content) {
   clearMessageBoard();
-  const message = document.getElementById(`${type}`);
+  const message = document.getElementById('control-message');
+  message.innerHTML = content;
 
   message.style.display = 'block';
 
-  setTimeout(() => { message.style.display = 'none'; }, 2000);
+  // setTimeout(() => { message.style.display = 'none'; }, 2000);
+}
+
+/**
+ * Hides a control messages from the players view
+ */
+function hideControlMessage() {
+  const message = document.getElementById('control-message');
+  message.style.display = 'none';
 }
 
 /**

--- a/gameengine.js
+++ b/gameengine.js
@@ -34,7 +34,7 @@ window.requestAnimFrame = (function requestAnimFrame() {
 class Timer {
   constructor() {
     this.gameTime = 0;
-    this.maxStep = 0.05;
+    this.maxStep = 0.02;
     this.wallLastTimestamp = 0;
   }
 

--- a/index.css
+++ b/index.css
@@ -79,7 +79,7 @@ h2 {
     width: 40px;
 }
 
-#message-overlay, #intro-message, #normal-message, #reversed-message  {
+#message-overlay, #intro-message, #normal-message, #control-message  {
     font-family: 'VT323', monospace;
     font-size: 2em;
     position: absolute;
@@ -96,7 +96,7 @@ h2 {
     top: 180px;
 }
 
-#normal-message, #reversed-message {
+#normal-message, #control-message {
     /* left: 265px; */
     top: 650px;
 }
@@ -132,6 +132,19 @@ div.key {
 	padding: 1px;
     margin: 10px 10px 10px 0px;
 }
+
+/* Blinking text */
+.blinking{
+    animation:blinkingText 0.8s infinite;
+}
+@keyframes blinkingText{
+    0%{     color: red;    }
+    49%{    color: transparent; }
+    50%{    color: transparent; }
+    99%{    color:transparent;  }
+    100%{   color: #000;    }
+}
+
 
 /*
     We need to expand the width of the space-key to make it distinguishable

--- a/index.html
+++ b/index.html
@@ -102,14 +102,14 @@
             <p id="message-line1"></p>
             <p id="message-line2"></p>
         </div>
-        <div class="overlay indicator" id="reversed-message">
+        <div class="overlay indicator" id="control-message">
             <p>Controls Reversed!</p>
         </div>
         <div class="overlay indicator" id="normal-message">
             <p>Controls Normalized!</p>
         </div>
         <div class="overlay" id="intro-message">
-            <p>Nukes and Origami</p>
+            <p class="blinking">Nukes and Origami</p>
             <div class="section one">
                 <div id="button">
                    Start Game

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const AM = new AssetManager();
 const ring = {};
 const sprite = {};
 const ship = {};
+const pattern = {};
 const projectile = {};
 const path = {};
 const scene = {};
@@ -378,7 +379,9 @@ class SceneManager {
         }
       }
 
-      let ship = new Ship(this.game, Object.assign({}, manifestCopy));
+      // The ship constructor **should** copy data; try without Object.assign() here
+      // let ship = new Ship(this.game, Object.assign({}, manifestCopy));
+      let ship = new Ship(this.game, manifestCopy);
 
       // Was the location overriden?
       if (wave.initialXPoints) {

--- a/objects.js
+++ b/objects.js
@@ -33,7 +33,7 @@ function loadTemplates() {
       const deltaRadius = this.current.velocity.radial * this.game.clockTick;
       const newPoint = getXandY(previous, {
         angle: this.current.angle,
-        radius: deltaRadius
+        radius: deltaRadius,
       });
       this.current.x = newPoint.x;
       this.current.y = newPoint.y;
@@ -60,7 +60,7 @@ function loadTemplates() {
     rotate: false,
     image: AM.getAsset('./img/glass_ball.png'),
     scale: 1.0,
-  }
+  };
 
   projectile.miniCrane = {
     radius: 15,
@@ -72,7 +72,7 @@ function loadTemplates() {
     radius: 5,
     rotate: true,
     sprite: sprite.testLaser.default,
-  }
+  };
 
   projectile.circleBullet = {
     radius: 6,
@@ -486,7 +486,7 @@ function loadTemplates() {
     rotation: {
       angle: 10,
       frequency: 2.0,
-      //speed: .1,
+      // speed: .1,
     },
     firing: {
       radius: 1,
@@ -540,7 +540,7 @@ function loadTemplates() {
       acceleration: {
         radial: 0,
         angular: 0,
-      }
+      },
     },
     rotation: {
       angle: 0,
@@ -560,7 +560,7 @@ function loadTemplates() {
         duration: 0.1,
         delay: 1,
       },
-    }
+    },
   };
 
   ring.jaredStinger = {
@@ -573,7 +573,7 @@ function loadTemplates() {
       acceleration: {
         radial: 0,
         angular: 0,
-      }
+      },
     },
     rotation: {
       angle: 0,
@@ -593,7 +593,7 @@ function loadTemplates() {
         duration: 0.4,
         delay: 0.2,
       },
-    }
+    },
   };
 
   ring.jaredWavy1 = {
@@ -606,12 +606,12 @@ function loadTemplates() {
       acceleration: {
         radial: 0,
         angular: 0,
-      }
+      },
     },
     rotation: {
       angle: 10,
       frequency: 1,
-      //speed: .1,
+      // speed: .1,
     },
     firing: {
       radius: 1,
@@ -627,7 +627,7 @@ function loadTemplates() {
         duration: 2.0,
         delay: 3.0,
       },
-    }
+    },
   };
 
 
@@ -686,7 +686,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new Shield(),
       radius: 50,
       sprite: sprite.crane.default,
       snapLine: 150,
@@ -704,7 +703,7 @@ function loadTemplates() {
       [0, 100, 5],
       [180, 100, 5],
       [0, 100, 5],
-      [90, 100, 60]
+      [90, 100, 60],
     ],
     weapon: ring.spiralAlpha4,
   };
@@ -713,7 +712,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new InvertedControls(),
       radius: 50,
       sprite: sprite.crane.default,
       snapLine: 150,
@@ -738,7 +736,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new InvertedControls(100),
       radius: 50,
       sprite: sprite.bat.default,
     },
@@ -783,13 +780,12 @@ function loadTemplates() {
       sprite: sprite.swallow.default,
     },
     weapon: ring.gap1,
-  }
+  };
 
   ship.dodgeOwl = {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new ExtraLife(),
       radius: 70,
       sprite: sprite.owl.default,
       snapLine: 150,
@@ -809,7 +805,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new InvertedControls(),
       radius: 50,
       sprite: sprite.bat.default,
       snapLine: 100,
@@ -833,7 +828,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new InvertedControls(),
       radius: 50,
       sprite: sprite.bat.default,
       snapLine: 100,
@@ -857,7 +851,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new ExtraLife(),
       radius: 30,
       sprite: sprite.bat.default,
       snapLine: 100,
@@ -877,7 +870,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new ExtraLife(),
       radius: 50,
       sprite: sprite.crane.default,
       snapLine: 150,
@@ -897,7 +889,6 @@ function loadTemplates() {
     config: {
       health: 3,
       hitValue: 5,
-      powerUp: new ExtraLife(),
       radius: 70,
       sprite: sprite.owl.default,
       snapLine: 150,
@@ -917,7 +908,6 @@ function loadTemplates() {
     config: {
       health: 15,
       hitValue: 5,
-      powerUp: new ExtraLife(),
       radius: 70,
       sprite: sprite.dove.default,
       snapLine: 200,
@@ -972,7 +962,7 @@ function loadTemplates() {
 
   /** *** PATHS **** */
   // I wonder what this does
-  path.doNothing = []
+  path.doNothing = [];
 
   // Slowly strafe right off screen
   path.strafeRight = [
@@ -1050,14 +1040,14 @@ function loadTemplates() {
           type: 'warning',
           text: ['Waves complete!', 'Get Ready...'],
           duration: 6,
-        }
+        },
       },
       // BOSS SWALLOW!!
       {
         numOfEnemies: 1,
         ships: [ship.swallow],
         paths: [
-          path.doNothing
+          path.doNothing,
         ],
         shipManifestOverride: [
           {
@@ -1072,14 +1062,14 @@ function loadTemplates() {
             weapon: {
               rotation: {
                 angle: 20,
-                frequency: 6
+                frequency: 6,
               },
               firing: {
                 count: 100,
                 radius: 250,
                 loadTime: 0.005,
-              }
-            }
+              },
+            },
           },
         ],
         waitUntilEnemiesGone: true,

--- a/power-up.js
+++ b/power-up.js
@@ -128,8 +128,10 @@ class RapidFire extends PowerUp {
         },
         speed: 60,
         powerUp(entity) {
-          if (entity.weapon.config.cooldownTime > 0.05) {
-            entity.weapon.config.cooldownTime -= 0.1;
+          // quick fix for change to weapon array. assuming that player only has one!
+          const ring = entity.weapon[0].ring;
+          if (ring.config.cooldownTime > 0.05) {
+            ring.config.cooldownTime -= 0.1;
             addPowerUp('./img/rapid-bullet.png', 'rapidFire');
           }
         },

--- a/power-up.js
+++ b/power-up.js
@@ -155,9 +155,32 @@ class InvertedControls extends PowerUp {
           entity.game.player.controls.hasInvertedControls = true;
           entity.game.player.controls.startTime = 0;
 
-          showTimedMessage('reversed-message');
+          showControlMessage('Controls Reversed!');
         },
       },
     };
   }
 }
+
+
+// From the collection of implemented powerups, retrieves and return a random one
+function getRandomPowerUp() {
+  const POWERUPS = [new ExtraLife(100), new RapidFire(100), new InvertedControls(100), new Shield(100)];
+
+  return POWERUPS[Math.floor(Math.random() * POWERUPS.length)];
+}
+
+function playAudio() {
+  // const audioUrl = 'http://soundbible.com/mp3/Pew_Pew-DKnight556-1379997159.mp3';
+  // const audioUrl = 'https://www.soundsnap.com/streamers/play.php?id=1550204891.5066:07dd2b3c0504a70acdff1bd83a645f7ce86994a0:262b3417d5dbe0d06abc7f96b07a3047eae0118c5fdd5701af379bde5b98e874b9563b8f1a66b799c23077581c33a646f84ea85eb8e15204927f1bd6f575ff8ad6667cf0c6d30e37025852868d02574fc92aa6d8fdfd83a6f947cf919dc52fe1f3e191ec49730a4ec815e1312c716c429c11cdd8e93469bd965f24688c5d2255b14b4460c7a5ba86ea106899be86c5207c1cda458aae71b28987a1ff36c99edbc0443e52284ed1291123ec325a0f192299412f9ef7c2e2855d96ab5f6ea0feba99cbde8cc606fe1306571706e163266d';
+  // const audioUrl = "http://soundbible.com/mp3/Laser%20Blasts-SoundBible.com-108608437.mp3"
+  // array with souds to cycle trough
+  // the more in the array, the faster you can retrigger the click
+  const audio2 = [new Audio(audioUrl), new Audio(audioUrl), new Audio(audioUrl), new Audio(audioUrl), new Audio(audioUrl)]; // put it has much has you want
+  let soundNb = 0; // counter
+
+  audio2[soundNb++ % audio2.length].play();
+}
+
+
+// $('.btn2').click(() => audio2[soundNb++ % audio2.length].play());

--- a/ship.js
+++ b/ship.js
@@ -127,7 +127,7 @@ class Ship extends Entity {
     this.snapLine = this.config.snapLine || 100;
     this.snapLineSpeed = this.config.snapLineSpeed || 300;
     this.hitValue = this.config.hitValue;
-    this.powerUp = this.config.powerUp;
+    this.powerUp = getRandomPowerUp();
 
     // additional fields
     this.idleTrans = false;
@@ -305,7 +305,8 @@ class Ship extends Entity {
 
   //
   static getInitPoint(game, manifest) {
-    let x, y;
+    let x; let
+      y;
     // Is origin specified?
     if (manifest.config.origin) {
       // Use one or both parameters specified
@@ -401,7 +402,7 @@ class Plane extends Ship {
       if (this.controls.startTime > this.controls.duration) {
         this.controls.hasInvertedControls = false;
         this.controls.startTime = 0;
-        showTimedMessage('normal-message');
+        hideControlMessage();
       }
     }
 
@@ -472,11 +473,11 @@ class Plane extends Ship {
       this.performManeuver();
     }
 
-    if (!this.game.keysDown.ArrowLeft &&
-      !this.game.keysDown.ArrowRight &&
-      !this.game.keysDown.ArrowUp &&
-      !this.game.keysDown.ArrowDown &&
-      !this.performingManeuver) {
+    if (!this.game.keysDown.ArrowLeft
+      && !this.game.keysDown.ArrowRight
+      && !this.game.keysDown.ArrowUp
+      && !this.game.keysDown.ArrowDown
+      && !this.performingManeuver) {
       this.sprite = this.idle;
       if (this.idleTrans) {
         this.idleCount += 1;
@@ -638,12 +639,12 @@ class Ring {
     if (!this.payload.acceleration) {
       this.payload.acceleration = {
         radial: 0,
-        angular: 0
+        angular: 0,
       };
     } else if (!(this.payload.acceleration instanceof Object)) {
       this.payload.acceleration = {
         radial: this.payload.acceleration,
-        angular: 0
+        angular: 0,
       };
     } else {
       this.payload.acceleration.angular = toRadians(this.payload.acceleration.angular);
@@ -652,7 +653,7 @@ class Ring {
     if (!this.payload.velocity) {
       this.payload.velocity = {
         radial: this.payload.speed,
-        angular: 0
+        angular: 0,
       };
     } else {
       this.payload.velocity.angular = toRadians(this.payload.velocity.angular);
@@ -728,7 +729,7 @@ class Ring {
       projectile.current.angle = this.current.angle + i * this.config.spacing;
       const currentPosition = getXandY(this.current, {
         radius: this.config.radius,
-        angle: projectile.current.angle
+        angle: projectile.current.angle,
       });
       projectile.current.x = currentPosition.x;
       projectile.current.y = currentPosition.y;
@@ -823,13 +824,13 @@ class Ring {
       const angle = this.current.angle + this.bay.length * this.config.spacing;
       const velocity = this.payload.velocity || {
         radial: this.payload.speed,
-        angular: 0
+        angular: 0,
       };
       const acceleration = this.payload.acceleration;
 
       const point = getXandY(this.current, {
         radius: this.config.radius,
-        angle
+        angle,
       });
       origin = {
         angle,
@@ -882,7 +883,7 @@ class Projectile extends Entity {
   constructor(game, manifest) {
     super(game, {
       x: manifest.origin.x,
-      y: manifest.origin.y
+      y: manifest.origin.y,
     });
 
     this.owner = manifest.owner;
@@ -900,11 +901,11 @@ class Projectile extends Entity {
       this.current.angle = manifest.angle;
       this.current.velocity = {
         radial: manifest.payload.speed,
-        angular: 0
+        angular: 0,
       };
       this.current.acceleration = {
         radial: 0,
-        angular: 0
+        angular: 0,
       };
       this.payload.powerUp = manifest.payload.powerUp;
     } else {
@@ -956,7 +957,7 @@ class Projectile extends Entity {
 
       const point = getXandY(previous, {
         angle: this.current.angle,
-        radius: deltaRadius
+        radius: deltaRadius,
       });
       this.current.x = point.x;
       this.current.y = point.y;
@@ -1009,7 +1010,7 @@ function getXandY(origin, current) {
   const y = origin.y + current.radius * Math.sin(current.angle);
   return {
     x,
-    y
+    y,
   };
 }
 

--- a/ship.js
+++ b/ship.js
@@ -160,8 +160,14 @@ class Ship extends Entity {
 
   draw() {
     this.sprite.drawFrame(this.game.clockTick, this.ctx, this.current.x, this.current.y);
-    this.weapon.draw();
+    this.drawWeapon();   
     super.draw();
+  }
+
+  drawWeapon() {
+    for (let i = 0; i < this.weapon.length; i++) {
+      this.weapon[i].ring.draw();
+    }
   }
 
   /**
@@ -203,7 +209,15 @@ class Ship extends Entity {
    * Weapons: manage turret initialization, rotation, firing and cooldown.
    */
   updateWeapons() {
-    this.weapon.update();
+    // assume that this.current has been updated to Ship's x,y postion
+    for (let i = 0; i < this.weapon.length; i++) {
+      let weapon = this.weapon[i];
+
+      weapon.ring.current.x = this.current.x + weapon.offset.x;
+      weapon.ring.current.y = this.current.y + weapon.offset.y;
+
+      weapon.ring.update();
+    }
   }
 
   /** Helm: manage path sequence. */
@@ -266,8 +280,28 @@ class Ship extends Entity {
   }
 
   initializeWeapon(weaponManifest) {
-    // do stuff here to configure a new weapon system.
-    this.weapon = new Ring(this, weaponManifest);
+    this.weapon = new Array();
+    
+    if (weaponManifest instanceof Array) {
+      // process the multi-ring format
+      for (let i = 0; i < weaponManifest.length; i++) {
+        var r = new Ring(this, weaponManifest[i].ring);
+        var offset = weaponManifest[i].offset || { x: 0, y: 0 };
+
+        this.weapon.push({
+          ring: r,
+          offset: offset,
+        });
+      }
+    } else {
+      // process the single-ring format  
+      var r = new Ring(this, weaponManifest);
+      
+      this.weapon.push({
+        ring: r,
+        offset: { x: 0, y: 0 },
+      });
+    }
   }
 
   /** Helpers for repeated work. */
@@ -305,8 +339,8 @@ class Ship extends Entity {
 
   //
   static getInitPoint(game, manifest) {
-    let x; let
-      y;
+    let x;
+    let y;
     // Is origin specified?
     if (manifest.config.origin) {
       // Use one or both parameters specified
@@ -346,9 +380,7 @@ class Plane extends Ship {
     this.rollRight = new Sprite(manifest.config.sprite.rollRight);
 
     // load weapon
-    if (manifest.weapon) {
-      this.weapon = new Ring(this, manifest.weapon);
-    }
+    // handled in Ship constructor
 
     // initial parameters
     this.sprite = this.idle;
@@ -382,7 +414,7 @@ class Plane extends Ship {
       duration: 10,
     };
   }
-
+  
   /** @override
    *  The Ship calls this method first on every update cycle.
    */
@@ -413,7 +445,7 @@ class Plane extends Ship {
         this.canRoll = true;
       }
     }
-
+        
     // This makes me worry about an overflow, or slowing our game down.
     // But it works great for what we need.
     // this.timeSinceLastSpacePress += this.game.clockTick;
@@ -473,7 +505,7 @@ class Plane extends Ship {
       this.performManeuver();
     }
 
-    if (!this.game.keysDown.ArrowLeft
+    if (!this.game.keysDown.ArrowLeft 
       && !this.game.keysDown.ArrowRight
       && !this.game.keysDown.ArrowUp
       && !this.game.keysDown.ArrowDown
@@ -545,7 +577,7 @@ class Plane extends Ship {
       this.sprite.drawFrame(this.game.clockTick, this.ctx, this.current.x, this.current.y);
     }
 
-    this.weapon.draw();
+    this.drawWeapon();
   }
 
   /**
@@ -593,7 +625,7 @@ class Plane extends Ship {
 
 
 /**
- * This weapon spawns a circle of bullets around the enemy and then fires them all at once at the player
+ * The ring holds a collection of bullets and updates/maintains their position prior to launch.
  */
 class Ring {
   constructor(owner, manifest) {
@@ -611,9 +643,12 @@ class Ring {
       this.sineFrequency = this.rotation.frequency || 1;
     }
 
+    // check for pattern
+    const pattern = manifest.firing.pattern;
+    const count = pattern ? pattern.sequence[0].length : manifest.firing.count || 1;
+    
     // compute spacing and adjust base angle
     let baseAngle = toRadians(manifest.firing.angle) || 0;
-    const count = manifest.firing.count || 1;
     let spacing = 0;
     let spread = 0;
 
@@ -637,8 +672,8 @@ class Ring {
 
     // convert acceleration and velocity to radians
     if (!this.payload.acceleration) {
-      this.payload.acceleration = {
-        radial: 0,
+      this.payload.acceleration = { 
+        radial: 0, 
         angular: 0,
       };
     } else if (!(this.payload.acceleration instanceof Object)) {
@@ -651,7 +686,7 @@ class Ring {
     }
 
     if (!this.payload.velocity) {
-      this.payload.velocity = {
+      this.payload.velocity = { 
         radial: this.payload.speed,
         angular: 0,
       };
@@ -664,15 +699,17 @@ class Ring {
       activeTime,
       baseAngle,
       count,
+      pattern,
       spread,
       spacing,
       waitTime,
       radius: manifest.firing.radius || this.owner.config.radius,
       viewTurret: manifest.firing.viewTurret,
       rapidReload: manifest.firing.rapidReload,
-      cooldownTime: manifest.firing.cooldownTime || 0.05,
-      loadTime: manifest.firing.loadTime || 0.05,
+      cooldownTime: manifest.firing.cooldownTime || 0,
+      loadTime: manifest.firing.loadTime || 0,
       targetPlayer: manifest.firing.targetPlayer || false,
+      targetLeadShot: manifest.firing.targetLeadShot || false,
     };
 
     // store instance variables
@@ -680,7 +717,7 @@ class Ring {
       x: this.owner.current.x,
       y: this.owner.current.y,
       angle: baseAngle,
-      isLeadShot: this.config.targetPalyer,
+      isLeadShot: this.config.targetLeadShot,
     };
 
     // set firing conditionals
@@ -692,22 +729,26 @@ class Ring {
       isCooling: false,
       isWaiting: false,
     };
+
+    if (pattern) {
+      this.status.roundLength = pattern.sequence.length;
+      this.status.round = this.status.roundLength;
+      this.config.waitTime = pattern.delay;
+      this.config.rapidReload = true;
+    }
   }
 
   update() {
     const game = this.owner.game;
+    //this.status.elapsedTime += game.clockTick;
     this.status.elapsedTime += game.clockTick;
 
     // update active time counter; used for the pulse delay
-    if (!this.status.isWaiting) {
-      this.status.elapsedActiveTime += game.clockTick;
-    }
+    this.status.elapsedActiveTime += game.clockTick;
+    //console.log("update=" + ++this.status.count + " interval=" + game.clockTick + " elapsed=" + this.status.elapsedTime);
+    
 
-    // update current ring coordinates before computing the location of each turret
-    // right now this uses the Ship position.
-    // TODO: point to weapon assembly + offset? for spacing-out the ring objects
-    this.current.x = this.owner.current.x;
-    this.current.y = this.owner.current.y;
+    // ring center position is updated by the Ship before calling Ring.update()
 
     // adjust angle for bay[0] if this ring is rotating
     if (this.fixedRotation) {
@@ -717,8 +758,8 @@ class Ring {
     } else if (this.sineAmplitude) {
       const delta = game.timer.getWave(this.sineAmplitude, this.sineFrequency);
       this.current.angle = this.config.baseAngle + delta;
-    } else if (this.current.isLeadShot) {
-      // moved target logic to here. only updates on lead shot.
+    } else if (this.current.isLeadShot || this.config.targetPlayer) {
+      // moved target logic to here. this will aim the 
       const target = this.getPlayerLocation(this.current);
       this.current.angle = target.angle - this.config.spread / 2;
       this.current.isLeadShot = false;
@@ -727,12 +768,15 @@ class Ring {
     for (let i = 0; i < this.bay.length; i++) {
       const projectile = this.bay[i];
       projectile.current.angle = this.current.angle + i * this.config.spacing;
+      
+      // TEST: only update x,y if turret is visible THIS WON'T WORK UNLESS WE CHECK AGAIN AT fireAll() :(
       const currentPosition = getXandY(this.current, {
-        radius: this.config.radius,
+        radius: this.config.radius, 
         angle: projectile.current.angle,
       });
       projectile.current.x = currentPosition.x;
       projectile.current.y = currentPosition.y;
+      
     }
 
     // now that all projectiles have been updated we can evaluate the next
@@ -752,23 +796,46 @@ class Ring {
       // Ready state
       // a player only fires on command, all others fire on ready
       if (!this.owner.isPlayer || game.keysDown.Space) {
-        this.fireAll();
+        if (this.config.pattern && --this.status.round > -1) {
+          this.fireLine(this.status.round);
+          this.status.isReady = false;
+          this.status.isCooling = true;
+          this.status.elapsedTime = 0;
+        } else if (this.config.pattern) {
+          // end pattern proceed to wait
+          this.status.round = this.status.roundLength;
+          this.status.isReady = false;
+          this.status.isWaiting = true;
+          this.status.elapsedTime = 0;
+        } else {
+          this.fireAll();
+          // update state
+          this.status.isReady = false;
+          this.status.isCooling = true;
+          this.status.elapsedTime = 0;
+        }
       }
     } else if (this.status.isCooling && this.status.elapsedTime > this.config.cooldownTime) {
       // Cooldown state
       this.status.isCooling = false;
-      this.status.isLoading = true;
       this.status.elapsedTime = 0;
+
+      if (this.status.elapsedActiveTime > this.config.activeTime) {
+        this.status.isWaiting = true;
+      } else {
+        this.status.isLoading = !this.config.rapidReload;
+        this.status.isReady = this.config.rapidReload;
+      }    
     } else if (this.status.isWaiting && this.status.elapsedTime > this.config.waitTime) {
       // Waiting state
-      // duration is defined by pulse configuration
       this.status.isWaiting = false;
-      this.status.isLoading = true;
+      this.status.isLoading = !this.config.rapidReload;
+      this.status.isReady = this.config.rapidReload;
       this.status.elapsedActiveTime = 0;
       this.status.elapsedTime = 0;
 
       // if tracking then set flag to track next shot
-      this.current.isLeadShot = this.config.targetPlayer;
+      this.current.isLeadShot = this.config.targetLeadShot;
     }
   }
 
@@ -784,6 +851,8 @@ class Ring {
   fireAll() {
     // the projectiles have been updated so just add to game and replace again
     // this previously fired all and then looped back to reload. was that better?
+    // console.log("fire");
+    
     for (let i = 0; i < this.bay.length; i++) {
       const projectile = this.bay[i];
       this.owner.game.addEntity(projectile);
@@ -797,15 +866,28 @@ class Ring {
     if (!this.config.rapidReload) {
       this.bay = [];
     }
+  }
 
-    this.status.isReady = false;
-    this.status.elapsedTime = 0;
+  fireLine(line) {
+    const row = this.config.pattern.sequence[line];
+    const last = this.bay.length - 1;
 
-    // set next state to cooldown unless the pulse period is over then begin waiting
-    if (this.status.elapsedActiveTime > this.config.activeTime) {
-      this.status.isWaiting = true;
-    } else {
-      this.status.isCooling = true;
+    for (let i = 0; i < this.bay.length; i++) {
+      const projectile = this.bay[i];
+      
+      if (row[last - i] === 1) {
+        this.owner.game.addEntity(projectile);
+      
+        if (this.config.rapidReload) {
+          this.bay[i] = this.loadNext(projectile);
+        }
+      
+      }
+    }
+
+    // if we did not reload then clear-out the bay
+    if (!this.config.rapidReload) {
+      this.bay = [];
     }
   }
 
@@ -828,8 +910,8 @@ class Ring {
       };
       const acceleration = this.payload.acceleration;
 
-      const point = getXandY(this.current, {
-        radius: this.config.radius,
+      const point = getXandY(this.current, { 
+        radius: this.config.radius, 
         angle,
       });
       origin = {
@@ -881,7 +963,7 @@ class Ring {
  */
 class Projectile extends Entity {
   constructor(game, manifest) {
-    super(game, {
+    super(game, { 
       x: manifest.origin.x,
       y: manifest.origin.y,
     });
@@ -893,18 +975,20 @@ class Projectile extends Entity {
 
     this.config = {
       radius: this.payload.radius,
-      isHoming: this.payload.isHoming,
+      baseAngle: this.current.angle || manifest.angle || 0,
     };
+    
+    this.status = Object.assign({}, this.payload.status)
 
     // support for origin format
     if (!this.current.angle) {
       this.current.angle = manifest.angle;
-      this.current.velocity = {
-        radial: manifest.payload.speed,
+      this.current.velocity = { 
+        radial: manifest.payload.speed, 
         angular: 0,
       };
-      this.current.acceleration = {
-        radial: 0,
+      this.current.acceleration = { 
+        radial: 0, 
         angular: 0,
       };
       this.payload.powerUp = manifest.payload.powerUp;
@@ -931,6 +1015,10 @@ class Projectile extends Entity {
     this.playerShot = (this.owner === game.player);
   }
 
+  /** Computes new position in polar coordinates using current velocity and acceleration.
+   *  A projectile that overrides update() agrees to use current.x and current.y for origin,
+   *  and store new polar coordinates in current.r and current.angle.
+   */
   update() {
     if (this.isOutsideScreen(this)) {
       this.removeFromWorld = true;
@@ -942,26 +1030,25 @@ class Projectile extends Entity {
       y: this.current.y,
     };
 
-    let deltaRadius = 0;
+    this.current.elapsedTime = this.game.clockTick;
 
     if (this.customUpdate) {
       this.customUpdate(this);
     } else {
-      const elapsedTime = this.game.clockTick;
+      const elapsedTime = this.current.elapsedTime;
 
       this.current.velocity.radial += this.current.acceleration.radial * elapsedTime;
-      deltaRadius = this.current.velocity.radial * elapsedTime;
+      this.current.r = this.current.velocity.radial * elapsedTime;
 
       this.current.velocity.angular += this.current.acceleration.angular * elapsedTime;
       this.current.angle += this.current.velocity.angular * elapsedTime;
-
-      const point = getXandY(previous, {
-        angle: this.current.angle,
-        radius: deltaRadius,
-      });
-      this.current.x = point.x;
-      this.current.y = point.y;
     }
+
+    // update x,y coordinates for game engine.
+    const point = getXandY(previous, { angle: this.current.angle, radius: this.current.r });
+    this.current.x = point.x;
+    this.current.y = point.y;
+    this.current.r = 0;
   }
 
   // default draw is used for sprite animations where draw() is not overriden
@@ -1008,8 +1095,8 @@ class Projectile extends Entity {
 function getXandY(origin, current) {
   const x = origin.x + current.radius * Math.cos(current.angle);
   const y = origin.y + current.radius * Math.sin(current.angle);
-  return {
-    x,
+  return { 
+    x, 
     y,
   };
 }

--- a/sprites.js
+++ b/sprites.js
@@ -1,5 +1,4 @@
 function loadSpriteSheets() {
-
   /** The Crane spritesheet configuration */
   sprite.crane = {
     default: {
@@ -14,10 +13,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 0.6,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   /** Experiment: mini-sized Crane projectiles */
   sprite.miniCrane = {
@@ -33,10 +32,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 0.5,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   sprite.bat = {
     default: {
@@ -51,10 +50,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 0.3,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   sprite.swallow = {
     default: {
@@ -84,10 +83,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 1,
           flip: false,
-        }
-      }
+        },
+      },
     },
-  }
+  };
 
   sprite.owl = {
     default: {
@@ -117,10 +116,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 1,
           flip: false,
-        }
-      }
+        },
+      },
     },
-  }
+  };
 
   sprite.dove = {
     default: {
@@ -135,10 +134,10 @@ function loadSpriteSheets() {
           timePerFrame: 0.1,
           scale: 0.3,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   // Power up sprites
   sprite.rainbowBall = {
@@ -157,7 +156,7 @@ function loadSpriteSheets() {
           flip: false,
         },
       },
-    }
+    },
   };
 
   sprite.shieldIcon = {
@@ -175,25 +174,23 @@ function loadSpriteSheets() {
           flip: false,
         },
       },
-    }
+    },
   };
 
   sprite.shield = {
     default: {
-      default: {
-        image: AM.getAsset('./img/shield.png'),
-        dimension: {
-          originX: 50,
-          originY: 50,
-          frameWidth: 50,
-          frameHeight: 50,
-          frameCount: 1,
-          timePerFrame: 30,
-          scale: 1,
-          flip: false,
-        },
+      image: AM.getAsset('./img/shield.png'),
+      dimension: {
+        originX: 50,
+        originY: 50,
+        frameWidth: 50,
+        frameHeight: 50,
+        frameCount: 1,
+        timePerFrame: 30,
+        scale: 1,
+        flip: false,
       },
-    }
+    },
   };
 
   sprite.rapidFire = {
@@ -211,7 +208,7 @@ function loadSpriteSheets() {
           flip: false,
         },
       },
-    }
+    },
   };
 
   /** Laser sprite */
@@ -244,10 +241,10 @@ function loadSpriteSheets() {
           timePerFrame: 20,
           scale: 0.5,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   sprite.cutLaser = {
     default: {
@@ -262,10 +259,10 @@ function loadSpriteSheets() {
           timePerFrame: 20,
           scale: 0.3,
           flip: false,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  };
 
   sprite.plane = {
     purple: {
@@ -293,7 +290,7 @@ function loadSpriteSheets() {
           timePerFrame: 0,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       left: {
         image: AM.getAsset('./img/purple-plane-small.png'),
@@ -306,7 +303,7 @@ function loadSpriteSheets() {
           timePerFrame: 0,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       rollRight: {
         image: AM.getAsset('./img/purple-plane-small.png'),
@@ -319,7 +316,7 @@ function loadSpriteSheets() {
           timePerFrame: 0.07,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       rollLeft: {
         image: AM.getAsset('./img/purple-plane-small.png'),
@@ -332,8 +329,8 @@ function loadSpriteSheets() {
           timePerFrame: 0.07,
           scale: 1.0,
           flip: false,
-        }
-      }
+        },
+      },
     },
     red: {
       default: {
@@ -347,7 +344,7 @@ function loadSpriteSheets() {
           timePerFrame: 0,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       right: {
         image: AM.getAsset('./img/plane-small.png'),
@@ -360,7 +357,7 @@ function loadSpriteSheets() {
           timePerFrame: 0,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       left: {
         image: AM.getAsset('./img/plane-small.png'),
@@ -373,7 +370,7 @@ function loadSpriteSheets() {
           timePerFrame: 0,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       rollRight: {
         image: AM.getAsset('./img/plane-small.png'),
@@ -386,7 +383,7 @@ function loadSpriteSheets() {
           timePerFrame: 0.07,
           scale: 1.0,
           flip: false,
-        }
+        },
       },
       rollLeft: {
         image: AM.getAsset('./img/plane-small.png'),
@@ -399,9 +396,8 @@ function loadSpriteSheets() {
           timePerFrame: 0.07,
           scale: 1.0,
           flip: false,
-        }
-      }
-    }
-  } //end purple plane
-
+        },
+      },
+    },
+  }; // end purple plane
 }


### PR DESCRIPTION
There is an example configuration in ship.testDove
I also added some ring patterns to ring.uni*
that exaggerated the line count for this PR.

Also, I simplified some logic in the Ring.update() I'm not sure that it mattered. I was attempting to remove stutter when there are a lot of bullets on the screen. On my machine, the average update interval is 18 ms. Occasionally, a single update takes > 40 ms. The gameengine has a maxStep value that was set at 50 ms, and I reduced this to 20 ms.

If this impacts other machines then we can increase maxStep to the original value.
